### PR TITLE
defect/Maroon-429-DuplicateLanguageKeys: removed duplicate keys from experiment MLG files

### DIFF
--- a/unity/Assets/Resources/MLG/titration.xml
+++ b/unity/Assets/Resources/MLG/titration.xml
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LanguageManager>
     <Translations>
-          
-        <Translation Key="PLAY">
-            <English>PLAY Simulation</English>
-            <German>Simulation starten</German>
-        </Translation>
-        
-        <Translation Key="RESET">
-            <English>RESET Simulation</English>
-            <German>Simulation zurücksetzen</German>
-        </Translation>
-
         <Translation Key="Titrant">
             <English>Titrant</English>
             <German>Titrant</German>

--- a/unity/Assets/Resources/MLG/wavepoint_experiment.xml
+++ b/unity/Assets/Resources/MLG/wavepoint_experiment.xml
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LanguageManager>
     <Translations>
-          
-        <Translation Key="PLAY">
-            <English>PLAY Simulation</English>
-            <German>Simulation starten</German>
-        </Translation>
-        
-        <Translation Key="RESET">
-            <English>RESET Simulation</English>
-            <German>Simulation zurücksetzen</German>
-        </Translation>
-        
         <Translation Key="ChangeWaveColor">
             <English>Change W-Color</English>
             <German>W-Farbe ändern</German>


### PR DESCRIPTION
Closes #429 