### PR TITLE
Maroon-486 Fix wrong player reference in CatalystControllerVR when starting from Bootstrapping.vr scene

### DIFF
--- a/unity/Assets/Maroon/scenes/experiments/Catalyst/Scripts/VR/CatalystControllerVR.cs
+++ b/unity/Assets/Maroon/scenes/experiments/Catalyst/Scripts/VR/CatalystControllerVR.cs
@@ -18,6 +18,8 @@ namespace Maroon.Chemistry.Catalyst.VR
         {
             base.Start();
 
+            player = VRPlayer.instance.gameObject;
+
             isVrVersion = true;
 
             foreach (var chart in lineChartsVRBox)


### PR DESCRIPTION
Fix #486 
The problem was that the Catalyst controller had a reference to the VR Player (which gets teleported), but the actual Player when starting from bootstrapping.vr scene is another one.
Quick fix sets the player in the VR Catalyst Controller to the VRPlayer instance.