### PR TITLE
Defect/Maroon-454 Fix concurrent workflow runs causing pipeline breakage

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,6 +18,12 @@ on:
   schedule:
     - cron: 50 5 * * *
 
+# only allow one workflow to run at a time
+# this should prevent us from running out of unity license seats
+# should also prevent more than one steampipe upload running simultaneously 
+concurrency:
+  group: default
+  cancel-in-progress: false
 
 jobs:
 


### PR DESCRIPTION
As mentioned [here](https://github.com/GameLabGraz/Maroon/issues/454#issuecomment-2182735082), the Unity licensing system seems unhappy when the Unity license used for our GitHub Actions workflow is activated on too many runners.

For now, the simplest fix is to just prevent more than one workflow instance at any given time.
In the future, a [Unity Licensing Server](https://docs.unity.com/licensing/en-us/manual) might be worth considering.

This is done by assigning the workflow to a [concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) group (in our case it is called `default`).

If a workflow is running, subsequent workflow runs are now queued to prevent parallel execution.

Closes #454 