### PR TITLE
Enhancement/maroon 491 ci status check

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -57,7 +57,7 @@ jobs:
       # Run tests
       - name: Run ${{ matrix.testMode }} tests
         id: tests
-        uses: game-ci/unity-test-runner@v4.1.1
+        uses: game-ci/unity-test-runner@v4.3.1
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -31,6 +31,9 @@ jobs:
   test:
     name: Run ${{ matrix.testMode }} tests
     runs-on: ubuntu-latest
+    # needed to create status check
+    permissions:
+      checks: write
     strategy:
       fail-fast: false
       matrix:
@@ -63,6 +66,8 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           testMode: ${{ matrix.testMode }}
           artifactsPath: test-${{ matrix.testMode }}-results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "Test Results: ${{ matrix.testMode }}"
 
       # Upload results
       - name: Upload test results


### PR DESCRIPTION
The `test` job now creates status checks for `playmode` and `editmode` test results.
Also, game-ci/unity-test-runner has been bumped to v4.3.1.

The results can be found here:
![Screenshot 2024-07-11 at 20-26-54 bump unity-test-runner action to version 4 3 1 · GameLabGraz_Maroon@2bc48ff](https://github.com/GameLabGraz/Maroon/assets/19763158/f7a0b8c2-1368-4d25-a714-d992b804e43b)

They look as follows:

✅ -> Pass
⚠️ -> Skipped
:x: -> Failed

![Screenshot 2024-07-11 at 20-19-46 bump unity-test-runner action to version 4 3 1 · GameLabGraz_Maroon@2bc48ff](https://github.com/GameLabGraz/Maroon/assets/19763158/6d8dac3e-4c79-4c49-b9b5-fc59737c624d)

Closes #491.

