### PR TITLE
Maintenance/Maroon-513 Fix CI failure caused by parallel license activation

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,24 +21,11 @@ on:
 
 jobs:
 
-  wait-in-queue:
-    name: Workflow queued
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-    # wait for max 3h
-    timeout-minutes: 180
-    steps:
-      - uses: jsok/serialize-workflow-action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-
   # test job matrix
   test:
     name: Run ${{ matrix.testMode }} tests
     runs-on: ubuntu-latest
-    needs: [wait-in-queue]
+
     # needed to create status check
     permissions:
       checks: write
@@ -67,9 +54,9 @@ jobs:
         id: tests
         uses: game-ci/unity-test-runner@v4.3.1
         env:
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_LICENSE: ${{ secrets.UNITY_PERSONAL_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_PERSONAL_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PERSONAL_PASSWORD }}
         with:
           projectPath: ${{ matrix.projectPath }}
           testMode: ${{ matrix.testMode }}
@@ -91,7 +78,6 @@ jobs:
   build:
     name: Build for ${{ matrix.maroonBuildTarget }}
     runs-on: ubuntu-latest
-    needs: [wait-in-queue]
 
     # create job matrix
     # runs job once for each build target
@@ -146,9 +132,9 @@ jobs:
         # environment vars needed by unity-builder to activate the unity license
         # defined in the Actions Secrets in the repo settings
         env:
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_LICENSE: ${{ secrets.UNITY_PERSONAL_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_PERSONAL_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PERSONAL_PASSWORD }}
 
         with:
           # run the custom build script

--- a/unity/Assets/Maroon/Editor/BuildPlayer.cs
+++ b/unity/Assets/Maroon/Editor/BuildPlayer.cs
@@ -245,13 +245,6 @@ namespace Maroon.Build
         public static void ActionsBuild()
         {
             var args = Environment.GetCommandLineArgs();
-
-            // array of build targets
-            MaroonBuildTarget[] targets = {
-                MaroonBuildTarget.PC,
-                MaroonBuildTarget.VR,
-                MaroonBuildTarget.WebGL
-            };
             
             // usage: -maroonBuildPath /path/to/build/dir -maroonBuildTarget (WebGL/PC/VR)
             // path is relative to project dir (./unity)


### PR DESCRIPTION
- Changed the workflow to use a personal Unity license.
- No longer queue workflow runs, as they _should_ be able to run in parallel now.

I've tried running multiple instance of the workflow simultaneously and was not able to reproduce the issue anymore.


Resolves #513.
Resolves #499.