### PR TITLE
Maroon-527 Add unit test to check whether experiment .cs files have namespace

### DIFF
--- a/unity/Assets/Tests/EditModeTests/ContentValidation/ExperimentFolderProvider.cs
+++ b/unity/Assets/Tests/EditModeTests/ContentValidation/ExperimentFolderProvider.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using UnityEngine;
+using System.IO;
+
+namespace Tests.EditModeTests.ContentValidation
+{
+    /// <summary>
+    /// Provides names of the experiment folders to test fixtures using the <c>TestFixtureSource</c> attribute
+    /// </summary>
+    public class ExperimentFolderProvider : IEnumerable
+    {
+        /// <summary>
+        /// Enumerates the folders of all experiments
+        /// </summary>
+        /// <returns>Array with [0] being the name of the experiment folder, and [1] being the absolute path to the folder</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            string[] experimentDirectories = Directory.GetDirectories(GetBaseExperimentsPath());
+            foreach (string experimentDirectory in experimentDirectories)
+            {
+                string dirName = Path.GetFileName(experimentDirectory.TrimEnd(Path.DirectorySeparatorChar));
+                yield return new string[] { dirName, Path.Combine(GetBaseExperimentsPath(), dirName) };
+            }
+        }
+
+        /// <summary>
+        /// Returns the path to the folder where all experiments subfolders are located.
+        /// </summary>
+        /// <returns>Absolute path to the Maroon/scenes/experiments folder.</returns>
+        public static string GetBaseExperimentsPath()
+        {
+            return Path.Combine(
+                Application.dataPath,
+                "Maroon/scenes/experiments"
+            );
+        }
+    }
+}

--- a/unity/Assets/Tests/EditModeTests/ContentValidation/ExperimentFolderProvider.cs.meta
+++ b/unity/Assets/Tests/EditModeTests/ContentValidation/ExperimentFolderProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9a9b2a47ac62234d868e26e6900469e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Tests/EditModeTests/ContentValidation/NamespaceTests.cs
+++ b/unity/Assets/Tests/EditModeTests/ContentValidation/NamespaceTests.cs
@@ -22,8 +22,9 @@ namespace Tests.EditModeTests.ContentValidation
             experimentFolderPath = absolutePathExperimentFolder;
         }
 
-        [SkipTestForScenesWithReason("Capacitor, Catalyst, CoulombsLaw, HuygensPrinciple, MinimumSpanningTree, PathFinding, " +
-            "PointWave, SortingAlgorithms, TitrationExperiment, VanDeGraaffGenerator, Whiteboard", 
+        // Do NOT add new experiments to this list of skipped experiments! Instead simply use namespaces in all .cs files
+        [SkipTestForScenesWithReason("3DMotionSimulation, Capacitor, Catalyst, CoulombsLaw, HuygensPrinciple, MinimumSpanningTree, " +
+            "PathFinding, PointWave, SortingAlgorithms, TitrationExperiment, VanDeGraaffGenerator, Whiteboard", 
             "Legacy code; should be ported to include namespaces some time soon.")]
         [Test, Description("Tests if every script of an experiment contains a namespace.")]
         public void TestNamespaceInScriptsForExperiments()

--- a/unity/Assets/Tests/EditModeTests/ContentValidation/NamespaceTests.cs
+++ b/unity/Assets/Tests/EditModeTests/ContentValidation/NamespaceTests.cs
@@ -3,22 +3,33 @@ using UnityEngine;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using static Tests.Utilities.Constants;
+using static Tests.Utilities.CustomAttributes;
+using static Tests.Utilities.UtilityFunctions;
 
 namespace Tests.EditModeTests.ContentValidation
 {
     [TestFixtureSource(typeof(ExperimentFolderProvider))]
     public class NamespaceTests
     {
+        private string experimentFolderName;
         private string experimentFolderPath;
 
-        public NamespaceTests(string experimentFolderName, string absolutePathExperimentFolder)
+        public NamespaceTests(string newExperimentFolderName, string absolutePathExperimentFolder)
         {
+            experimentFolderName = newExperimentFolderName;
             experimentFolderPath = absolutePathExperimentFolder;
         }
 
+        [SkipTestForScenesWithReason("Capacitor, Catalyst, CoulombsLaw, HuygensPrinciple, MinimumSpanningTree, PathFinding, " +
+            "PointWave, SortingAlgorithms, TitrationExperiment, VanDeGraaffGenerator, Whiteboard", 
+            "Legacy code; should be ported to include namespaces some time soon.")]
         [Test, Description("Tests if every script of an experiment contains a namespace.")]
         public void TestNamespaceInScriptsForExperiments()
         {
+            SkipCheck();
+
             const string STRING_TO_CHECK = "namespace ";
 
             // Get all .cs files
@@ -31,6 +42,24 @@ namespace Tests.EditModeTests.ContentValidation
                 Assert.IsTrue(fileContents.Contains(STRING_TO_CHECK), "Class in file " + csFilePath + " needs to be in a namespace.");
             }
             Debug.Log("All " + csFiles.Count().ToString() + " .cs files contain a namespace.");
+        }
+
+        /// <summary>
+        /// Skips test if check is triggered
+        /// </summary>
+        /// <param name="callingMethodName">test method name (automatically provided through <see cref="CallerMemberNameAttribute"/>)</param>
+        /// <remarks>
+        /// Wrapper for utility function <see cref="SkipCheckBase"/> with shorter param list and fixture specific arguments
+        /// </remarks>
+        protected void SkipCheck([CallerMemberName] string callingMethodName = null)
+        {
+            SkipCheckBase<NamespaceTests>(
+                "", 
+                null,
+                experimentFolderName, 
+                "", 
+                callingMethodName
+            );
         }
     }
 }

--- a/unity/Assets/Tests/EditModeTests/ContentValidation/NamespaceTests.cs
+++ b/unity/Assets/Tests/EditModeTests/ContentValidation/NamespaceTests.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Tests.EditModeTests.ContentValidation
+{
+    [TestFixtureSource(typeof(ExperimentFolderProvider))]
+    public class NamespaceTests
+    {
+        private string experimentFolderPath;
+
+        public NamespaceTests(string experimentFolderName, string absolutePathExperimentFolder)
+        {
+            experimentFolderPath = absolutePathExperimentFolder;
+        }
+
+        [Test, Description("Tests if every script of an experiment contains a namespace.")]
+        public void TestNamespaceInScriptsForExperiments()
+        {
+            const string STRING_TO_CHECK = "namespace ";
+
+            // Get all .cs files
+            IEnumerable<string> csFiles = Directory.EnumerateFiles(experimentFolderPath, "*.*", SearchOption.AllDirectories)
+                .Where(s => Path.GetExtension(s).TrimStart('.').ToLowerInvariant().Equals("cs"));
+
+            foreach (string csFilePath in csFiles)
+            {
+                string fileContents = File.ReadAllText(csFilePath);
+                Assert.IsTrue(fileContents.Contains(STRING_TO_CHECK), "Class in file " + csFilePath + " needs to be in a namespace.");
+            }
+            Debug.Log("All " + csFiles.Count().ToString() + " .cs files contain a namespace.");
+        }
+    }
+}

--- a/unity/Assets/Tests/EditModeTests/ContentValidation/NamespaceTests.cs.meta
+++ b/unity/Assets/Tests/EditModeTests/ContentValidation/NamespaceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84dfc98f7047df3489cb66fca00fabf8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Tests/Utilities/CustomAttributes.cs
+++ b/unity/Assets/Tests/Utilities/CustomAttributes.cs
@@ -95,7 +95,7 @@ namespace Tests.Utilities
             }
 
             // Check if the object is part of our ExperimentSetting prefab otherwise skip test
-            if (!objectNamesFromExperimentPrefab.Any(x => x.ToUpper().Contains(nameOfObjectUnderTest.ToUpper())))
+            if (objectNamesFromExperimentPrefab != null && !objectNamesFromExperimentPrefab.Any(x => x.ToUpper().Contains(nameOfObjectUnderTest.ToUpper())))
             {
                 Assert.Ignore(
                     $"{ExperimentPrefabName + sceneType} contains no {nameOfObjectUnderTest} - skipping test!");


### PR DESCRIPTION
Fix #527 
uses the implementation described in the issue;

Note that the ExperimentFolderProvider is the same as in PR #526 