### PR TITLE
Maroon-339 [Pendulum] Fix reset not working properly

### DIFF
--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Pendulum.pc.unity
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Pendulum.pc.unity
@@ -3814,11 +3814,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5202824136093578685, guid: f1d29f2ffd6e5e44a8358b7534612945,
-        type: 3}
-      propertyPath: _ropeWeidth
-      value: 0.005
-      objectReference: {fileID: 0}
     - target: {fileID: 5202824136149113556, guid: f1d29f2ffd6e5e44a8358b7534612945,
         type: 3}
       propertyPath: simulationRunning.onNewValueFromSystem.m_PersistentCalls.m_Calls.Array.size

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
@@ -196,6 +196,8 @@ namespace Maroon.Physics
 
             _rigidBody.velocity = Vector3.zero;
             _rigidBody.angularVelocity = Vector3.zero;
+
+            Elongation = 0f;
         }
 
         public void PendulumReleased()

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
@@ -151,7 +151,6 @@ namespace Maroon.Physics.Pendulum
                     Debug.Log("Pendulum Maximum" + _currentElongation + " - " + _previousElongation);
                 }
             }
-
         }
 
         public float GetDeflection()
@@ -188,6 +187,8 @@ namespace Maroon.Physics.Pendulum
             _rigidBody.angularVelocity = Vector3.zero;
 
             Elongation = 0f;
+
+            UpdatePendulum();
         }
 
         public void PendulumReleased()

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using UnityEngine.Events;
 
-namespace Maroon.Physics
+namespace Maroon.Physics.Pendulum
 {
     [RequireComponent(typeof(HingeJoint))]
     public class Pendulum : PausableObject, IResetObject

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
@@ -1,20 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 
 namespace Maroon.Physics
 {
-  [Serializable]
-  public class Node
-  {
-    public string interestingValue = "value";
-    //The field below is what makes the serialization data become huge because
-    //it introduces a 'class cycle'.
-    public List<Node> children = new List<Node>();
-  }
-
-  [RequireComponent(typeof(HingeJoint))]
+    [RequireComponent(typeof(HingeJoint))]
     public class Pendulum : PausableObject, IResetObject
     {
         public QuantityFloat weight = 1.0f;

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/PendulumRope.cs
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/PendulumRope.cs
@@ -14,7 +14,7 @@ namespace Maroon.Physics
         private GameObject _weight;
 
         [SerializeField]
-        private float _ropeWeidth = 0.001f;
+        private float _ropeWidth = 0.001f;
 
         protected override void Start()
         {
@@ -22,7 +22,7 @@ namespace Maroon.Physics
             _lineRenderer = GetComponent<AdvancedLineRenderer>();
             _lineRenderer.useWorldSpace = true;
             _lineRenderer.InitLineRenderer();
-            _lineRenderer.SetWidth(_ropeWeidth, _ropeWeidth);
+            _lineRenderer.SetWidth(_ropeWidth, _ropeWidth);
 
             SimulationController.Instance.OnStop.AddListener(() => { DrawRope();});
 

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/PendulumRope.cs
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/PendulumRope.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace Maroon.Physics
+namespace Maroon.Physics.Pendulum
 {
     [RequireComponent(typeof(AdvancedLineRenderer))]
     public class PendulumRope : PausableObject, IResetObject

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/PlatformControls/PC_SwingPendulum.cs
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/PlatformControls/PC_SwingPendulum.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Maroon.Physics;
+using Maroon.Physics.Pendulum;
 using UnityEngine;
 using UnityEngine.Events;
 

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/prefabs/PendulumExperiment.prefab
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/prefabs/PendulumExperiment.prefab
@@ -1600,7 +1600,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _ropeJoint: {fileID: 5202824134377885964}
   _weight: {fileID: 5202824134415402285}
-  _ropeWeidth: 0.001
+  _ropeWidth: 0.005
 --- !u!1 &5202824136149113554
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Fix #339 
Addresses the following points:
- Fix pendulum position and rotation not resetting properly (the user used to need to press the reset button twice)
- Fix max/min rotation/elongation label not resetting
- Fix width typo
- Change script namespace to Maroon.Physics.Pendulum namespace