### PR TITLE
Maroon-268 [Pendulum] Improve behaviour of pendulum weight & rope length changes

### DIFF
--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Pendulum.pc.unity
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Pendulum.pc.unity
@@ -2492,7 +2492,7 @@ PrefabInstance:
     - target: {fileID: 2399235266715423803, guid: 09c73ed225a086845b90fbeaba0dc5ea,
         type: 3}
       propertyPath: m_MaxValue
-      value: 2
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 2399235266715423803, guid: 09c73ed225a086845b90fbeaba0dc5ea,
         type: 3}

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
@@ -71,7 +71,7 @@ namespace Maroon.Physics.Pendulum
         {
             //weight
             _rigidBody.mass = weight.Value;
-            _weightObj.transform.localScale = Vector3.one * weight.Value;
+            _weightObj.transform.localScale = Vector3.one * Mathf.Pow(weight.Value, 1f / 3f); // 3D object changes with cube root of weight
             
             //rope len
             var pos = _weightObj.transform.position;

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/Scripts/Pendulum.cs
@@ -26,7 +26,7 @@ namespace Maroon.Physics.Pendulum
         private float _startWeight;
 
         private float _startRopeLength;
-        private Vector3 _startRopePosition;
+        private Vector3 _startRopeLocalPosition;
 
         private bool _pendulumRelease = false;
 
@@ -74,9 +74,7 @@ namespace Maroon.Physics.Pendulum
             _weightObj.transform.localScale = Vector3.one * Mathf.Pow(weight.Value, 1f / 3f); // 3D object changes with cube root of weight
             
             //rope len
-            var pos = _weightObj.transform.position;
-            var moveDirection = (_startRopePosition - _standRopeJoint.transform.position).normalized;
-            _weightObj.transform.position = _startRopePosition + moveDirection * (ropeLength.Value - _startRopeLength);
+            _weightObj.transform.localPosition = _startRopeLocalPosition + Vector3.down * (ropeLength.Value - _startRopeLength);
         }
         
         public float Elongation
@@ -96,7 +94,7 @@ namespace Maroon.Physics.Pendulum
             _startRot = transform.rotation;
             _startWeight = Weight;
             _startRopeLength = RopeLength;
-            _startRopePosition = _weightObj.transform.position;
+            _startRopeLocalPosition = _weightObj.transform.localPosition;
         }
 
         protected override void HandleUpdate()

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/prefabs/PendulumExperiment.prefab
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/prefabs/PendulumExperiment.prefab
@@ -1292,7 +1292,7 @@ MonoBehaviour:
     allowSystemChange: 1
     _value: 1
     minValue: 1
-    maxValue: 2
+    maxValue: 5
     onValueChanged:
       m_PersistentCalls:
         m_Calls: []

--- a/unity/Assets/Maroon/scenes/experiments/Pendulum/prefabs/PendulumExperiment.prefab
+++ b/unity/Assets/Maroon/scenes/experiments/Pendulum/prefabs/PendulumExperiment.prefab
@@ -1045,7 +1045,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &5202824135287962044
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1288,7 +1288,7 @@ MonoBehaviour:
   weight:
     assessmentName: weight
     isDynamic: 0
-    alwaysSendValueChangedEvent: 0
+    alwaysSendValueChangedEvent: 1
     allowSystemChange: 1
     _value: 1
     minValue: 1
@@ -1338,7 +1338,7 @@ MonoBehaviour:
   ropeLength:
     assessmentName: ropeLength
     isDynamic: 0
-    alwaysSendValueChangedEvent: 0
+    alwaysSendValueChangedEvent: 1
     allowSystemChange: 1
     _value: 0.3
     minValue: 0.2


### PR DESCRIPTION
Fix #268 

Improvements:

- Fix pendulum object changing its angle when changing the weight or rope length
- Fix Pendulum size changing model size: used to be linearly, not it is changes with cuberoot
- Fix text (weight and rope length) on pendulum weight not updating
- Max weight of pendulum is now 5kg instead of 2kg (allows for more interesting experiments, and size of pendulum object does not look ridiculous anymore at 5kg now)