### PR TITLE
Maroon-565 Pause Menu ensures cursor is visible and not locked

### DIFF
--- a/unity/Assets/Maroon/reusableGui/Menu/PrefabsBase/scrMenu.cs
+++ b/unity/Assets/Maroon/reusableGui/Menu/PrefabsBase/scrMenu.cs
@@ -5,6 +5,9 @@ public class scrMenu : MonoBehaviour
     // #################################################################################################################
     // Members
 
+    private CursorLockMode cursorLockModeBeforeMenu = CursorLockMode.None;
+    private bool cursorVisibleBeforeMenu = true;
+
     // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     // Open/Close
 
@@ -75,6 +78,12 @@ public class scrMenu : MonoBehaviour
 
     public void OpenMenu()
     {
+        // Save cursor state and ensure cursor is useable
+        cursorLockModeBeforeMenu = Cursor.lockState;
+        cursorVisibleBeforeMenu = Cursor.visible;
+        Cursor.lockState = CursorLockMode.None;
+        Cursor.visible = true;
+
         this.Canvas.SetActive(true);
         this.IsOpen = true;
     }
@@ -88,6 +97,12 @@ public class scrMenu : MonoBehaviour
         {
             this.RemoveAllMenuColumnsButFirst();
         }
+
+        // Restore cursor state
+        Cursor.visible = cursorVisibleBeforeMenu;
+        Cursor.lockState = cursorLockModeBeforeMenu;
+        cursorLockModeBeforeMenu = CursorLockMode.None;
+        cursorVisibleBeforeMenu = true;
     }
 
     // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/unity/Assets/Maroon/reusableGui/Menu/PrefabsColumns/scrMenuColumnPauseMenu.cs
+++ b/unity/Assets/Maroon/reusableGui/Menu/PrefabsColumns/scrMenuColumnPauseMenu.cs
@@ -95,6 +95,8 @@ public class scrMenuColumnPauseMenu : MonoBehaviour
             SceneManager.Instance.LoadSceneRequest(this.targetMainMenuScenePC);
         }
         this.Menu.CloseMenu();
+        Cursor.lockState = CursorLockMode.None;
+        Cursor.visible = true;
     }
 
     private void OnClickResume()


### PR DESCRIPTION
Close #565 
pause menu now saves the cursor visibility and lockmode when it is opened, then sets the visibility to true and lockMode.None;
when closing it, it restores the lockmode&visibility again