### PR TITLE
Maroon-579 Add Confirm dialogue to Build for All option

### DIFF
--- a/unity/Assets/Maroon/Editor/BuildPlayer.cs
+++ b/unity/Assets/Maroon/Editor/BuildPlayer.cs
@@ -100,7 +100,14 @@ namespace Maroon.Build
         [MenuItem("Maroon Build/All Platforms, Conventional and Standalone")]
         public static void BuildAll()
         {
-            var buildPath = EditorUtility.SaveFolderPanel("Choose Build Location", string.Empty, "Build");
+            bool confirmed = EditorUtility.DisplayDialog("Build for ALL?", 
+                "Are you sure you want to build everything?\n" +
+                "This includes a build for the Laboratory version as well as ALL standalone versions, for ALL platforms.", 
+                "Yes, build everything", "Cancel");
+            if (!confirmed)
+                return;
+
+            var buildPath = EditorUtility.SaveFolderPanel("Choose Build Location (All Platforms, Conventional and Standalone)", string.Empty, "Build");
 
             if (buildPath.Length == 0)
             {
@@ -126,7 +133,7 @@ namespace Maroon.Build
                     return;
                 }
 
-                buildPath = EditorUtility.SaveFolderPanel("Choose Build Location", "Build", "Laboratory");
+                buildPath = EditorUtility.SaveFolderPanel("Choose Build Location (Conventional Maroon)", "Build", "Laboratory");
 
                 if(buildPath.Length == 0)
                 {
@@ -179,8 +186,14 @@ namespace Maroon.Build
                 {
                     return;
                 }
+                bool confirmed = EditorUtility.DisplayDialog("Build Standalone Experiments?",
+                    "Are you sure you build all Standalone Experiments?\n" +
+                    "This will create a separate build for EACH experiment. If you want to create one build that includes all experiments, choose \"Conventional Maroon\"",
+                    "Yes, build standalone experiments", "Cancel");
+                if (!confirmed)
+                    return;
 
-                buildPath = EditorUtility.SaveFolderPanel("Choose Build Location", "Build", "Experiments");
+                buildPath = EditorUtility.SaveFolderPanel("Choose Build Location (Standalone Experiments)", "Build", "Experiments");
 
                 if (buildPath.Length == 0)
                 {

--- a/unity/Assets/Tests/EditModeTests/ContentValidation/RunSceneValidationTestsDuringBuild.cs
+++ b/unity/Assets/Tests/EditModeTests/ContentValidation/RunSceneValidationTestsDuringBuild.cs
@@ -15,17 +15,36 @@ namespace Tests.EditModeTests.ContentValidation
     /// The build process stops if any test should fail and a popup with all failed tests is shown.
     /// </summary>
     /// <remarks>
-    /// To disable the tests during build, simply comment out the entire class :)
+    /// To disable the tests during build, in the Unity Editor select "Maroon Build" -> "Settings" -> "ENABLE/DISABLE SceneValidationTests during Build"
     /// </remarks>
     public class RunSceneValidationTestsDuringBuild : IProcessSceneWithReport
     {
+        private static bool doRunSceneValidationTestsDuringBuild = true;
         public int callbackOrder => 0;
         private readonly Regex _experimentNameRegex = new Regex(@"\w+\.(pc|vr)");
+
+        [MenuItem("Maroon Build/Settings/ENABLE SceneValidationTests during Build", priority = 101)]
+        static void TurnOnSceneValidationTests()
+        {
+            doRunSceneValidationTestsDuringBuild = true;
+            Debug.Log("Running SceneValidationTests during Build has been ENABLED.");
+        }
+
+        [MenuItem("Maroon Build/Settings/DISABLE SceneValidationTests during Build", priority = 100)]
+        static void TurnOffSceneValidationTests()
+        {
+            doRunSceneValidationTestsDuringBuild = false;
+            Debug.Log("Running SceneValidationTests during Build has been DISABLED.");
+        }
 
         public void OnProcessScene(Scene scene, BuildReport report)
         {
             // Don't execute scene validation tests during playmode
             if (report == null)
+                return;
+
+            // Skip SceneValidation tests if turned off
+            if (!doRunSceneValidationTestsDuringBuild)
                 return;
 
             var scenePath = scene.path;


### PR DESCRIPTION
Close #579 

Changes:

- Adds confirm dialogue before building for all platforms, and also before building standalone experiments
- Choosing save path dialogue now also includes some information about the selected build option
- Also added the possibility to disable the scene validation tests during a build (Maroon Build -> Settings -> Enable/Disable scene validation tests during build), as we now have Github Actions that run the tests as well, so I think it is justified to have this option available to create e.g. faster WebGL builds for testing purposes.