### PR TITLE
Maroon-586 [CI] Run EditMode tests in parallel

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,8 +32,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        projectPath: [unity]
-        testMode: [playmode, editmode]
+        include:
+          # first matrix job (playmode, no params)
+          - projectPath: unity
+            testMode: playmode
+            params: ""
+          # second matrix job (editmode, run in parallel)
+          - projectPath: unity
+            testMode: editmode
+            params: "-runSynchronously"
 
     steps:
     
@@ -63,6 +70,7 @@ jobs:
           artifactsPath: test-${{ matrix.testMode }}-results
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: "Test Results: ${{ matrix.testMode }}"
+          customParameters: ${{ matrix.params }}
 
       # Upload results
       - name: Upload test results


### PR DESCRIPTION
The EditMode tests now take about [6 minutes](https://github.com/GameLabGraz/Maroon/actions/runs/13436404236/job/37539593005), instead of [~19 minutes](https://github.com/GameLabGraz/Maroon/actions/metrics/performance?dateRangeType=DATE_RANGE_TYPE_CUSTOM&tab=jobs&range=1735689600000-1739923200000):


No (additional) tests are skipped, after this change.
(400/445 tests are executed [before](https://github.com/GameLabGraz/Maroon/actions/runs/13431669445/job/37525793233) and [after](https://github.com/GameLabGraz/Maroon/actions/runs/13436404236/job/37539984811))

If this breaks the EditMode tests for any reason down the line, it should be easily revertible.

Closes #586