### PR TITLE
Maroon-590 [Optics] Allow JSON presets to use Quaternion or Euler angles for rotations

### DIFF
--- a/unity/Assets/Maroon/reusableScripts/ExperimentParameters/ExperimentParameters.cs
+++ b/unity/Assets/Maroon/reusableScripts/ExperimentParameters/ExperimentParameters.cs
@@ -7,7 +7,9 @@ namespace Maroon.ReusableScripts.ExperimentParameters
     [System.Serializable]
     public abstract class ExperimentParameters
     {
-        // Called when the ExperimentParameters have been loaded
+        /// <summary>
+        /// Called when the ExperimentParameters have been loaded
+        /// </summary>
         public virtual void OnLoaded()
         {
         }

--- a/unity/Assets/Maroon/reusableScripts/ExperimentParameters/ExperimentParameters.cs
+++ b/unity/Assets/Maroon/reusableScripts/ExperimentParameters/ExperimentParameters.cs
@@ -7,5 +7,9 @@ namespace Maroon.ReusableScripts.ExperimentParameters
     [System.Serializable]
     public abstract class ExperimentParameters
     {
+        // Called when the ExperimentParameters have been loaded
+        public virtual void OnLoaded()
+        {
+        }
     }
 }

--- a/unity/Assets/Maroon/reusableScripts/ExperimentParameters/ParameterLoader.cs
+++ b/unity/Assets/Maroon/reusableScripts/ExperimentParameters/ParameterLoader.cs
@@ -212,6 +212,7 @@ namespace Maroon.ReusableScripts.ExperimentParameters
             }
             else
             {
+                MostRecentParameters.OnLoaded();
                 Debug.Log("Successfully parsed ExperimentParameters: " + MostRecentParameters.GetType());
             }
             parametersLoaded?.Invoke(MostRecentParameters);

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/FarsightedEye.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/FarsightedEye.json
@@ -45,24 +45,24 @@
         "rayDistributionAngle": 4.0,
         "enableMeshRenderer": true,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.638,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.EyeParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "f": 0.024,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.9,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -73,13 +73,13 @@
         "Rc": 0.065,
         "A": 1.458,
         "B": 3540.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.882,
           "y": 0.0,
           "z": 0.577001035
         },
-        "rotation": null
+        "Rotation": null
       }
     ]
   }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/FarsightedEye.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/FarsightedEye.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Farsighted Eye",
   "rayThickness": 0.15,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.12,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 3.0
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.12,
       "y": 3.0,
       "z": 2.08
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/FocalLength.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/FocalLength.json
@@ -3,7 +3,7 @@
   "presetNameTranslationKey": "Focal Length",
   "rayThickness": 1.2,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.065,
@@ -11,6 +11,12 @@
       "z": 1.0
     },
     "Rotation": {
+      "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+      "x": 52.5000038,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,19 +26,25 @@
     "FOV": 36.0
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.06,
       "y": 3.0,
       "z": 2.1
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,
       "z": 0.0,
       "w": 0.707106769
+    },
+    "Rotation": {
+      "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+      "x": 90.0,
+      "y": 0.0,
+      "z": 0.0
     },
     "FOV": 36.0
   },

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/FocalLength.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/FocalLength.json
@@ -56,13 +56,13 @@
         "numberOfRays": 16,
         "distanceBetweenRays": 0.0038,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.2,
           "y": 0.0,
           "z": 0.62
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -73,13 +73,13 @@
         "Rc": 0.065,
         "A": 1.728,
         "B": 13420.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.7,
           "y": 0.0,
           "z": 0.62
         },
-        "rotation": null
+        "Rotation": null
       }
     ]
   }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/GalileanTelescope.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/GalileanTelescope.json
@@ -44,25 +44,25 @@
         "numberOfRays": 20,
         "distanceBetweenRays": 0.0014,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.65,
           "y": 0.0,
           "z": 0.6
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.ApertureParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "Rin": 0.005,
         "Rout": 0.015,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.783,
           "y": 0.0,
           "z": 0.6
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -73,13 +73,13 @@
         "Rc": 0.015,
         "A": 1.7,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.788,
           "y": 0.0,
           "z": 0.6
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -90,49 +90,49 @@
         "Rc": 0.005,
         "A": 1.7,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.848,
           "y": 0.0,
           "z": 0.6
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.EyeParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "f": 0.024,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.865,
           "y": 0.0,
           "z": 0.6
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.LightComponent.ParallelSourceParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "numberOfRays": 20,
         "distanceBetweenRays": 0.0014,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.65,
           "y": 0.0,
           "z": 0.56
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.ApertureParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "Rin": 0.005,
         "Rout": 0.015,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.783,
           "y": 0.0,
           "z": 0.56
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -143,13 +143,13 @@
         "Rc": 0.015,
         "A": 1.7,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.788,
           "y": 0.0,
           "z": 0.56
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -160,24 +160,24 @@
         "Rc": 0.005,
         "A": 1.7,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.848,
           "y": 0.0,
           "z": 0.56
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.EyeParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "f": 0.024,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.865,
           "y": 0.0,
           "z": 0.56
         },
-        "rotation": null
+        "Rotation": null
       }
     ]
   }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/GalileanTelescope.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/GalileanTelescope.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Galilean Telescope",
   "rayThickness": 0.15,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.168,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 3.5
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.168,
       "y": 3.0,
       "z": 2.08
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/KeplerianTelescope.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/KeplerianTelescope.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Keplerian Telescope",
   "rayThickness": 0.15,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.1682,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 3.5
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.1682,
       "y": 3.0,
       "z": 2.08
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/KeplerianTelescope.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/KeplerianTelescope.json
@@ -44,25 +44,25 @@
         "numberOfRays": 20,
         "distanceBetweenRays": 0.0014,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.65,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.ApertureParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "Rin": 0.005,
         "Rout": 0.015,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.74,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -73,13 +73,13 @@
         "Rc": 0.015,
         "A": 1.7,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.75,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -90,24 +90,24 @@
         "Rc": 0.05,
         "A": 1.7,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.85,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.EyeParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "f": 0.024,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.867,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       }
     ]
   }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/LensAndMirror.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/LensAndMirror.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Lens and Mirror",
   "rayThickness": 1.2,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.065,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 30.0
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.065,
       "y": 3.0,
       "z": 2.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/LensAndMirror.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/LensAndMirror.json
@@ -53,13 +53,13 @@
             720.0
           ]
         },
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.3,
           "y": 0.0,
           "z": 0.6
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -70,25 +70,25 @@
         "Rc": 0.065,
         "A": 1.728,
         "B": 13420.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.6,
           "y": 0.0,
           "z": 0.57
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.MirrorParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "R": 0.1,
         "Rc": 0.07,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 2.2,
           "y": 0.0,
           "z": 0.4
         },
-        "rotation": {
+        "Rotation": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.0,
           "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/LightEmittingDiode.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/LightEmittingDiode.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Light Emitting Diode",
   "rayThickness": 0.3,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.17,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 7.0
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.17,
       "y": 3.0,
       "z": 2.08
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/LightEmittingDiode.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/LightEmittingDiode.json
@@ -45,13 +45,13 @@
         "rayDistributionAngle": 360.0,
         "enableMeshRenderer": false,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.82,
           "y": 0.0,
           "z": 0.56
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -62,13 +62,13 @@
         "Rc": 0.03,
         "A": 1.41,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.82,
           "y": 0.0,
           "z": 0.57
         },
-        "rotation": {
+        "Rotation": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 0.0,
           "y": 0.0,
@@ -79,13 +79,13 @@
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.MirrorParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "R": 0.01,
         "Rc": 0.01,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.82,
           "y": 0.0,
           "z": 0.55
         },
-        "rotation": {
+        "Rotation": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 0.0,
           "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/MagnifyingGlass.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/MagnifyingGlass.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Magnifying Glass",
   "rayThickness": 0.15,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.12,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 3.0
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.12,
       "y": 3.0,
       "z": 2.08
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/MagnifyingGlass.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/MagnifyingGlass.json
@@ -45,13 +45,13 @@
         "rayDistributionAngle": 22.0,
         "enableMeshRenderer": true,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.78,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -62,24 +62,24 @@
         "Rc": 0.065,
         "A": 1.458,
         "B": 3540.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.866,
           "y": 0.0,
           "z": 0.577001035
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.EyeParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "f": 0.024,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.9,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       }
     ]
   }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/Microscope.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/Microscope.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Microscope",
   "rayThickness": 0.08,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.12,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 3.0
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.12,
       "y": 3.0,
       "z": 2.08
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/Microscope.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/Microscope.json
@@ -45,25 +45,25 @@
         "rayDistributionAngle": 22.0,
         "enableMeshRenderer": true,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.78,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.ApertureParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "Rin": 0.002,
         "Rout": 0.05,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.809,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -74,13 +74,13 @@
         "Rc": 0.52678,
         "A": 1.7,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.81,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -91,24 +91,24 @@
         "Rc": 0.52678,
         "A": 1.7,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.89,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.EyeParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "f": 0.024,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.907,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       }
     ]
   }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/NearsightedEye.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/NearsightedEye.json
@@ -44,24 +44,24 @@
         "numberOfRays": 20,
         "distanceBetweenRays": 0.000400000019,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.78,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.EyeParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "f": 0.022,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.9,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -72,13 +72,13 @@
         "Rc": 0.065,
         "A": 1.458,
         "B": 3540.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.882,
           "y": 0.0,
           "z": 0.577001035
         },
-        "rotation": null
+        "Rotation": null
       }
     ]
   }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/NearsightedEye.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/NearsightedEye.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Nearsighted Eye",
   "rayThickness": 0.15,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.12,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 3.0
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.12,
       "y": 3.0,
       "z": 2.08
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/NewtonianTelescope.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/NewtonianTelescope.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Newtonian Telescope",
   "rayThickness": 0.15,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.1825,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 3.5
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.1825,
       "y": 3.0,
       "z": 2.08
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/NewtonianTelescope.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/NewtonianTelescope.json
@@ -44,75 +44,75 @@
         "numberOfRays": 20,
         "distanceBetweenRays": 0.0014,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.65,
           "y": 0.0,
           "z": 0.55
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.LightComponent.ParallelSourceParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "numberOfRays": 20,
         "distanceBetweenRays": 0.0014,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.65,
           "y": 0.0,
           "z": 0.578
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.LightComponent.ParallelSourceParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "numberOfRays": 20,
         "distanceBetweenRays": 0.0014,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.65,
           "y": 0.0,
           "z": 0.606
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.ApertureParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "Rin": 0.019,
         "Rout": 0.1,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.735,
           "y": 0.0,
           "z": 0.56
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.MirrorParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "R": -0.2,
         "Rc": 0.02,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.856,
           "y": 0.0,
           "z": 0.56
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.MirrorParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "R": 0.5,
         "Rc": 0.006,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.77,
           "y": 0.0,
           "z": 0.56
         },
-        "rotation": {
+        "Rotation": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.0,
           "y": 0.0,
@@ -123,13 +123,13 @@
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.ApertureParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "Rin": 0.0,
         "Rout": 0.006,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.77,
           "y": 0.0,
           "z": 0.5595
         },
-        "rotation": {
+        "Rotation": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.0,
           "y": 0.0,
@@ -145,13 +145,13 @@
         "Rc": 0.006855,
         "A": 1.63,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.77,
           "y": 0.0,
           "z": 0.592
         },
-        "rotation": {
+        "Rotation": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 0.0,
           "y": 0.0,
@@ -161,13 +161,13 @@
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.EyeParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "f": 0.024,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.77,
           "y": 0.0,
           "z": 0.611
         },
-        "rotation": {
+        "Rotation": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 0.0,
           "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/OpticalFiber.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/OpticalFiber.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Optical Fiber",
   "rayThickness": 0.15,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.124,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 3.0
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.124,
       "y": 3.0,
       "z": 2.08
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/OpticalFiber.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/OpticalFiber.json
@@ -44,13 +44,13 @@
         "numberOfRays": 20,
         "distanceBetweenRays": 0.000400000019,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.75,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -61,13 +61,13 @@
         "Rc": 0.009367,
         "A": 1.7,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.8,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.LensParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
@@ -78,13 +78,13 @@
         "Rc": 0.002,
         "A": 1.7,
         "B": 0.0,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.872,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       }
     ]
   }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/StandardEye.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/StandardEye.json
@@ -3,14 +3,14 @@
   "presetNameTranslationKey": "Standard Eye",
   "rayThickness": 0.15,
   "cameraSettingBaseView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.12,
       "y": 2.6,
       "z": 1.0
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.4422887,
       "y": 0.0,
@@ -20,14 +20,14 @@
     "FOV": 3.0
   },
   "cameraSettingTopView": {
-    "$type": "Maroon.Physics.Optics.Camera.CameraControls+CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "$type": "Maroon.Physics.Optics.Camera.CameraSetting, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
     "Position": {
       "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": -0.12,
       "y": 3.0,
       "z": 2.08
     },
-    "Rotation": {
+    "RotationQuaternion": {
       "$type": "Maroon.Utils.SerializableQuaternion, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
       "x": 0.707106769,
       "y": 0.0,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/StandardEye.json
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Resources/Presets/StandardEye.json
@@ -44,24 +44,24 @@
         "numberOfRays": 20,
         "distanceBetweenRays": 0.000400000019,
         "waveLengths": null,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.78,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       },
       {
         "$type": "Maroon.Physics.Optics.TableObject.OpticalComponent.EyeParameters, Maroon.Experiments.OpticsSimulations, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
         "f": 0.024,
-        "position": {
+        "Position": {
           "$type": "Maroon.Utils.SerializableVector3, Maroon.ReusableScripts.Utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
           "x": 1.9,
           "y": 0.0,
           "z": 0.577
         },
-        "rotation": null
+        "Rotation": null
       }
     ]
   }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraControls.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraControls.cs
@@ -60,7 +60,7 @@ namespace Maroon.Physics.Optics.Camera
         private void UpdateCamera(CameraSetting cs)
         {
             _cam.transform.position = cs.Position;
-            _cam.transform.rotation = cs.Rotation;
+            _cam.transform.rotation = cs.RotationQuaternion;
             _cam.fieldOfView = cs.FOV;
 
             if (!isTopView)   CopyCameraSetting(_currentView, out _baseView);
@@ -93,12 +93,12 @@ namespace Maroon.Physics.Optics.Camera
             {
                 float t = (Time.time - startTime) / 1f;
                 camTransform.position = Vector3.Lerp(_currentView.Position, cs.Position, t * 1.5f);
-                camTransform.rotation = Quaternion.Slerp(_currentView.Rotation, cs.Rotation, t * 1.5f);
+                camTransform.rotation = Quaternion.Slerp(_currentView.RotationQuaternion, cs.RotationQuaternion, t * 1.5f);
                 _cam.fieldOfView = Mathf.Lerp(_currentView.FOV, cs.FOV, t * 1.5f);
                 yield return null;
             }
             camTransform.position = cs.Position;
-            camTransform.rotation = cs.Rotation;
+            camTransform.rotation = cs.RotationQuaternion;
             _cam.fieldOfView = cs.FOV;
             CopyCameraSetting(cs, out _currentView);
 
@@ -116,7 +116,7 @@ namespace Maroon.Physics.Optics.Camera
         
         private void CopyCameraSetting(CameraSetting a, out CameraSetting b)
         {
-            b = new CameraSetting (a.Position, a.Rotation, a.FOV);
+            b = new CameraSetting(a.Position, a.Rotation, a.FOV);
         }
     }
 }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraControls.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraControls.cs
@@ -22,22 +22,7 @@ namespace Maroon.Physics.Optics.Camera
         private float _moveFactor;
         
         public bool IsTopView => isTopView;
-
-        [System.Serializable]
-        public struct CameraSetting
-        {
-            public SerializableVector3 Position;
-            public SerializableQuaternion Rotation;
-            public float FOV;
-
-            public CameraSetting(Vector3 position, Quaternion rotation, float fov)
-            {
-                Position = new SerializableVector3(position);
-                Rotation = new SerializableQuaternion(rotation);
-                FOV = fov;
-            }
-        }
-        
+                
         private void Start()
         {
             _cam = GetComponent<UnityEngine.Camera>();

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraSetting.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraSetting.cs
@@ -1,0 +1,20 @@
+using Maroon.Utils;
+using UnityEngine;
+
+namespace Maroon.Physics.Optics.Camera
+{
+    [System.Serializable]
+    public struct CameraSetting
+    {
+        public SerializableVector3 Position;
+        public SerializableQuaternion Rotation;
+        public float FOV;
+
+        public CameraSetting(Vector3 position, Quaternion rotation, float fov)
+        {
+            Position = new SerializableVector3(position);
+            Rotation = new SerializableQuaternion(rotation);
+            FOV = fov;
+        }
+    }
+}

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraSetting.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraSetting.cs
@@ -7,14 +7,39 @@ namespace Maroon.Physics.Optics.Camera
     public struct CameraSetting
     {
         public SerializableVector3 Position;
-        public SerializableQuaternion Rotation;
+        public SerializableQuaternion RotationQuaternion;
+        /// <summary>
+        /// Rotation as Euler angles. If RotationQuaternion is set, this value will be overriden.
+        /// </summary>
+        public SerializableVector3 Rotation;
         public float FOV;
 
-        public CameraSetting(Vector3 position, Quaternion rotation, float fov)
+        public CameraSetting(Vector3 position, Quaternion rotationQuaternion, float fov)
         {
             Position = new SerializableVector3(position);
-            Rotation = new SerializableQuaternion(rotation);
+            RotationQuaternion = new SerializableQuaternion(rotationQuaternion);
+            Rotation = new SerializableVector3(rotationQuaternion.eulerAngles);
             FOV = fov;
+        }
+
+        public CameraSetting(Vector3 position, Vector3 rotationEuler, float fov)
+        {
+            Position = new SerializableVector3(position);
+            RotationQuaternion = new SerializableQuaternion(Quaternion.Euler(rotationEuler));
+            Rotation = new SerializableVector3(rotationEuler);
+            FOV = fov;
+        }
+
+        public void CheckRotations()
+        {
+            if (RotationQuaternion != null)
+            {
+                Rotation = new SerializableVector3(RotationQuaternion.Get().eulerAngles);
+            }
+            else if (Rotation != null)
+            {
+                RotationQuaternion = new SerializableQuaternion(Quaternion.Euler(Rotation.Get()));
+            }
         }
     }
 }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraSetting.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraSetting.cs
@@ -6,12 +6,21 @@ namespace Maroon.Physics.Optics.Camera
     [System.Serializable]
     public struct CameraSetting
     {
+        /// <summary>
+        /// The position of the camera.
+        /// </summary>
         public SerializableVector3 Position;
+        /// <summary>
+        /// The camera's rotation as Quaternion. If set, this value will override Rotation.
+        /// </summary>
         public SerializableQuaternion RotationQuaternion;
         /// <summary>
-        /// Rotation as Euler angles. If RotationQuaternion is set, this value will be overriden.
+        /// The camera's rotation as Euler angles. If RotationQuaternion is set, this value will be overriden.
         /// </summary>
         public SerializableVector3 Rotation;
+        /// <summary>
+        /// The field of view of the camera.
+        /// </summary>
         public float FOV;
 
         public CameraSetting(Vector3 position, Quaternion rotationQuaternion, float fov)

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraSetting.cs.meta
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Camera/CameraSetting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac97fd222b648864782aa9fe32cdab17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Manager/PresetManager.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Manager/PresetManager.cs
@@ -28,7 +28,7 @@ namespace Maroon.Physics.Optics.Manager
         [SerializeField] private Aperture aperture;
         [SerializeField] private Eye eye;
         [SerializeField] private Lens lens;
-        [SerializeField] private TableObject.OpticalComponent.Mirror mirror;
+        [SerializeField] private Mirror mirror;
 
         [Header("Camera")] 
         [SerializeField] private GameObject mainCamera;
@@ -97,7 +97,7 @@ namespace Maroon.Physics.Optics.Manager
 
                 if (componentParameters is LightComponentParameters lightComponentParameters)
                 {
-                    LightComponent lightComp = _lcm.AddLightComponent((LightComponent)prefab, lightComponentParameters.position, lightComponentParameters.rotation, lightComponentParameters.waveLengths);
+                    LightComponent lightComp = _lcm.AddLightComponent((LightComponent)prefab, lightComponentParameters.Position, lightComponentParameters.Rotation, lightComponentParameters.waveLengths);
 
                     switch (lightComponentParameters)
                     {
@@ -117,7 +117,7 @@ namespace Maroon.Physics.Optics.Manager
                 }
                 else if (componentParameters is OpticalComponentParameters opticalComponentParameters)
                 {
-                    OpticalComponent opticalComp = _ocm.AddOpticalComponent((OpticalComponent)prefab, opticalComponentParameters.position, opticalComponentParameters.rotation);
+                    OpticalComponent opticalComp = _ocm.AddOpticalComponent((OpticalComponent)prefab, opticalComponentParameters.Position, opticalComponentParameters.Rotation);
 
                     switch (opticalComponentParameters)
                     {
@@ -215,12 +215,12 @@ namespace Maroon.Physics.Optics.Manager
                 {
                     new ParallelSourceParameters()
                     {
-                        position = new Vector3(1.2f, 0, 0.62f),
+                        Position = new Vector3(1.2f, 0, 0.62f),
                         distanceBetweenRays = 0.0038f,
                     },
                     new LensParameters()
                     {
-                        position = new Vector3(1.70f, 0, 0.62f),
+                        Position = new Vector3(1.70f, 0, 0.62f),
                         R1 = Constants.Biconvex.Item1,
                         R2 = Constants.Biconvex.Item2,
                         d1 = Constants.Biconvex.Item3,

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Manager/PresetManager.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Manager/PresetManager.cs
@@ -208,8 +208,8 @@ namespace Maroon.Physics.Optics.Manager
             {
                 presetNameTranslationKey = "Focal Length",
                 rayThickness = Constants.BaseRayThicknessInMM,
-                cameraSettingBaseView = new CameraControls.CameraSetting(new Vector3(-0.065f, 2.6f, 1.0f), Constants.BaseCamRot, 36),
-                cameraSettingTopView = new CameraControls.CameraSetting(new Vector3(-0.06f, 3, 2.1f), Constants.TopCamRot, 36),
+                cameraSettingBaseView = new CameraSetting(new Vector3(-0.065f, 2.6f, 1.0f), Constants.BaseCamRot, 36),
+                cameraSettingTopView = new CameraSetting(new Vector3(-0.06f, 3, 2.1f), Constants.TopCamRot, 36),
 
                 tableObjectParameters = new List<TableObjectParameters>()
                 {

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Manager/PresetManager.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/Manager/PresetManager.cs
@@ -57,7 +57,7 @@ namespace Maroon.Physics.Optics.Manager
             _uim = UIManager.Instance;
             _em = ExperimentManager.Instance;
             _camControls = mainCamera.GetComponent<CameraControls>();
-            
+
             parameterLoader.LoadJsonFromFileIndex(0, true);
         }
 

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/OpticsParameters.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/OpticsParameters.cs
@@ -20,6 +20,11 @@ namespace Maroon.Physics.Optics.Manager
 
             cameraSettingBaseView.CheckRotations();
             cameraSettingTopView.CheckRotations();
+
+            foreach (TableObjectParameters top in tableObjectParameters)
+            {
+                top.CheckRotations();
+            }
         }
     }
 }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/OpticsParameters.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/OpticsParameters.cs
@@ -1,7 +1,7 @@
+using Maroon.Physics.Optics.Camera;
 using Maroon.Physics.Optics.TableObject;
 using Maroon.ReusableScripts.ExperimentParameters;
 using System.Collections.Generic;
-using static Maroon.Physics.Optics.Camera.CameraControls;
 
 namespace Maroon.Physics.Optics.Manager
 {

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/OpticsParameters.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/OpticsParameters.cs
@@ -13,5 +13,13 @@ namespace Maroon.Physics.Optics.Manager
         public CameraSetting cameraSettingBaseView;
         public CameraSetting cameraSettingTopView;
         public List<TableObjectParameters> tableObjectParameters;
+
+        public override void OnLoaded()
+        {
+            base.OnLoaded();
+
+            cameraSettingBaseView.CheckRotations();
+            cameraSettingTopView.CheckRotations();
+        }
     }
 }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/TableObject/TableObjectParameters.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/TableObject/TableObjectParameters.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 using Maroon.Utils;
 
 namespace Maroon.Physics.Optics.TableObject
@@ -8,7 +5,7 @@ namespace Maroon.Physics.Optics.TableObject
     [System.Serializable]
     public class TableObjectParameters
     {
-        public SerializableVector3 position;
-        public SerializableVector3? rotation;
+        public SerializableVector3 Position;
+        public SerializableVector3? Rotation;
     }
 }

--- a/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/TableObject/TableObjectParameters.cs
+++ b/unity/Assets/Maroon/scenes/experiments/OpticsSimulations/Scripts/TableObject/TableObjectParameters.cs
@@ -1,11 +1,34 @@
 using Maroon.Utils;
+using UnityEngine;
 
 namespace Maroon.Physics.Optics.TableObject
 {
     [System.Serializable]
     public class TableObjectParameters
     {
+        /// <summary>
+        /// The position of the TableObject.
+        /// </summary>
         public SerializableVector3 Position;
+        /// <summary>
+        /// The rotation of the TableObject in the form of Euler angles. Will overriden by RotationQuaternion if that is is set.
+        /// </summary>
         public SerializableVector3? Rotation;
+        /// <summary>
+        /// The rotation of the TableObject in the form of a Quaternion. Will override Rotation if this variable set.
+        /// </summary>
+        public SerializableQuaternion? RotationQuaternion;
+
+        public void CheckRotations()
+        {
+            if (RotationQuaternion != null)
+            {
+                Rotation = new SerializableVector3(RotationQuaternion.Get().eulerAngles);
+            }
+            else if (Rotation != null)
+            {
+                RotationQuaternion = new SerializableQuaternion(Quaternion.Euler(Rotation.Get()));
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #590 
The rotation of the camera settings as well as the rotation of table objects can now either be set via the variable `Rotation`(Euler angle), or via the variable `RotationQuaternion` (Quaternion). If both are set, the `RotationQuaternion` will be used.
Furthermore, moved CameraSetting to its own file.