### PR TITLE
Maroon-594 [PlanetarySystem] Fix keyboard shortcut to toggle sunlight not updating UI toggle

### DIFF
--- a/unity/Assets/Maroon/scenes/experiments/PlanetarySystem/Scripts/PlanetSortingGameController.cs
+++ b/unity/Assets/Maroon/scenes/experiments/PlanetarySystem/Scripts/PlanetSortingGameController.cs
@@ -12,33 +12,7 @@ namespace Maroon.Experiments.PlanetarySystem
         [SerializeField] private Light sunLight;
         [SerializeField] private ParticleSystem solarFlares;
         //---------------------------------------------------------------------------------------
-
-        /// <summary>
-        /// HandleKeyInput sunlight 
-        /// </summary>
-        private void Update()
-        {
-            HandleKeyInput();
-        }
-
-
-        // HandlesKeyInput during Update
-        #region KeyInput
-        /// <summary>
-        /// HandlesKeyInput during Update
-        /// toggle sunlight                   on key [L]
-        /// </summary>
-        private void HandleKeyInput()
-        {
-            if (Input.GetKeyDown(KeyCode.L))
-            {
-                sunLight.gameObject.SetActive(!sunLight.gameObject.activeSelf);
-                // Sync the toggle button state with sunLight's state
-                ToggleSunLight(sunLight.gameObject.activeSelf);
-            }
-        }
-        #endregion KeyInput
-
+        
 
         // handles the SortingGame
         #region SortingGameSpawner
@@ -151,7 +125,6 @@ namespace Maroon.Experiments.PlanetarySystem
         /// <param name="isOn"></param>
         public void ToggleSunLight(bool isOn)
         {
-            //Debug.Log("PlanetSortingGameController(): UIToggleSunLight = " + !isOn);
             sunLight.gameObject.SetActive(isOn);
         }
         #endregion SGToggleFunctions

--- a/unity/Assets/Maroon/scenes/experiments/PlanetarySystem/Scripts/PlanetarySimulationUIController.cs
+++ b/unity/Assets/Maroon/scenes/experiments/PlanetarySystem/Scripts/PlanetarySimulationUIController.cs
@@ -46,6 +46,25 @@ namespace Maroon.Experiments.PlanetarySystem
             CheckCollisionsWithSun();
         }
 
+        private void Update()
+        {
+            HandleKeyInput();
+        }
+
+        #region KeyInput
+        /// <summary>
+        /// HandlesKeyInput during Update
+        /// toggle sunlight on key [L]
+        /// </summary>
+        private void HandleKeyInput()
+        {
+            if (Input.GetKeyDown(KeyCode.L))
+            {
+                toggleSunLight.isOn = !toggleSunLight.isOn;
+            }
+        }
+        #endregion KeyInput
+
 
         /// <summary>
         /// Initialize UI event listeners for toggle buttons
@@ -214,7 +233,6 @@ namespace Maroon.Experiments.PlanetarySystem
         /// <summary>
         /// ResetPlanetarySystemSimulation on reset and on StartPlanetarySystemSimulation
         /// </summary>
-
         public void ResetPlanetarySystemSimulation()
         {
             bool hide = false;


### PR DESCRIPTION
Fix #594 
Moved the keyboard toggle code into the UI class, as that's probably the more fitting place for it anyway.